### PR TITLE
feat: ApiKeyPath field under Repositories in Bitbucket was moved back…

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,10 +8,10 @@ import (
 
 type Config struct {
 	Bitbucket struct {
-		Repositories []struct {
-			Owner      string `yaml:"owner"`
-			Name       string `yaml:"name"`
-			ApiKeyPath string `yaml:"apiKeyPath"`
+		AllRepoApiKeyPath string `yaml:"allRepoApiKeyPath"`
+		Repositories      []struct {
+			Owner string `yaml:"owner"`
+			Name  string `yaml:"name"`
 		} `yaml:"repositories"`
 	} `yaml:"bitbucket"`
 }

--- a/internal/config/config.yml
+++ b/internal/config/config.yml
@@ -1,5 +1,5 @@
 bitbucket:
+  allRepoApiKeyPath: "/Users/y_yoshida/.api-tokens/bitbucket/bitbucket-access-token.json"
   repositories:
     - owner: "teihenn"
       name: "static-code-analysis-test"
-      apiKeyPath: "/Users/y_yoshida/.api-tokens/bitbucket/static-code-analysis-test-access-token.txt"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,13 +16,18 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	/* ----- assert ----- */
+	expectedApiKeyPath := "expected/api/key/path"
+	if actual.Bitbucket.AllRepoApiKeyPath != expectedApiKeyPath {
+		t.Errorf("expected %s, got %s",
+			expectedApiKeyPath, actual.Bitbucket.AllRepoApiKeyPath)
+	}
+
 	expectedRepositories := []struct {
-		Owner      string
-		Name       string
-		ApiKeyPath string
+		Owner string
+		Name  string
 	}{
-		{Owner: "expectedOwner1", Name: "expectedRepoName1", ApiKeyPath: "expected/api/key/path"},
-		{Owner: "expectedOwner2", Name: "expectedRepoName2", ApiKeyPath: "expected/api/key/path"},
+		{Owner: "expectedOwner1", Name: "expectedRepoName1"},
+		{Owner: "expectedOwner2", Name: "expectedRepoName2"},
 	}
 
 	if len(actual.Bitbucket.Repositories) != len(expectedRepositories) {
@@ -33,12 +38,11 @@ func TestLoadConfig(t *testing.T) {
 		if actual.Bitbucket.Repositories[i].Owner != repo.Owner ||
 			actual.Bitbucket.Repositories[i].Name != repo.Name {
 			t.Errorf(
-				"expected repository %d: owner=%s, name=%s, apiKeyPath=%s; "+
-					"got owner=%s, name=%s, apiKeyPath=%s",
-				i, repo.Owner, repo.Name, repo.ApiKeyPath,
+				"expected repository %d: owner=%s, name=%s; "+
+					"got owner=%s, name=%s",
+				i, repo.Owner, repo.Name,
 				actual.Bitbucket.Repositories[i].Owner,
 				actual.Bitbucket.Repositories[i].Name,
-				actual.Bitbucket.Repositories[i].ApiKeyPath,
 			)
 		}
 	}

--- a/internal/config/testdata/test_config.yml
+++ b/internal/config/testdata/test_config.yml
@@ -1,5 +1,5 @@
 bitbucket:
-  apiKeyPath: "expected/api/key/path"
+  allRepoApiKeyPath: "expected/api/key/path"
   repositories:
     - owner: "expectedOwner1"
       name: "expectedRepoName1"


### PR DESCRIPTION
… under Bitbucket and renamed to allRepoApiKeyPath